### PR TITLE
Upgrade to phpunit 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     "kleijnweb/php-api-hydrator": "^v1.0.0-alpha2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.2",
-    "phpunit/phpunit-mock-objects": "^3.1",
+    "phpunit/phpunit": "^6.4",
     "symfony/framework-bundle": ">=2.8.7",
     "symfony/security-bundle": ">=2.8.7",
     "symfony/monolog-bridge": ">=2.8.7",

--- a/tests/unit/BundleTest.php
+++ b/tests/unit/BundleTest.php
@@ -10,24 +10,19 @@ namespace KleijnWeb\PhpApi\RoutingBundle\Tests\DependencyInjection;
 
 use KleijnWeb\PhpApi\RoutingBundle\DependencyInjection\PhpApiRoutingExtension;
 use KleijnWeb\PhpApi\RoutingBundle\PhpApiRoutingBundle;
+use PHPUnit\Framework\TestCase;
 
-class BundleTest extends \PHPUnit_Framework_TestCase
+class BundleTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function canGetExtension()
+    public function testCanGetExtension()
     {
         $routingBundle = new PhpApiRoutingBundle();
-        $this->assertInstanceOf(PhpApiRoutingExtension::class, $routingBundle->getContainerExtension());
+        self::assertInstanceOf(PhpApiRoutingExtension::class, $routingBundle->getContainerExtension());
     }
 
-    /**
-     * @test
-     */
-    public function canGetNamespace()
+    public function testCanGetNamespace()
     {
         $routingBundle = new PhpApiRoutingBundle();
-        $this->assertSame('KleijnWeb\PhpApi\RoutingBundle', $routingBundle->getNamespace());
+        self::assertSame('KleijnWeb\PhpApi\RoutingBundle', $routingBundle->getNamespace());
     }
 }

--- a/tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/DependencyInjection/ConfigurationTest.php
@@ -11,18 +11,15 @@
 
 namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection;
 
-
 use KleijnWeb\PhpApi\RoutingBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function willReturnTreeBuilder()
+    public function testWillReturnTreeBuilder()
     {
         $extension =  new Configuration();
-        $this->assertInstanceOf(TreeBuilder::class, $extension->getConfigTreeBuilder());
+        self::assertInstanceOf(TreeBuilder::class, $extension->getConfigTreeBuilder());
     }
 }

--- a/tests/unit/DependencyInjection/ExtensionTest.php
+++ b/tests/unit/DependencyInjection/ExtensionTest.php
@@ -9,9 +9,10 @@
 namespace KleijnWeb\PhpApi\RoutingBundle\Tests\DependencyInjection;
 
 use KleijnWeb\PhpApi\RoutingBundle\DependencyInjection\PhpApiRoutingExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ExtensionTest extends \PHPUnit_Framework_TestCase
+class ExtensionTest extends TestCase
 {
     /**
      * @var PhpApiRoutingExtension
@@ -23,23 +24,17 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension = new PhpApiRoutingExtension();
     }
 
-    /**
-     * @test
-     */
-    public function hasRouteLoaderTag()
+    public function testHasRouteLoaderTag()
     {
         $container = new ContainerBuilder();
         $this->extension->load([], $container);
-        $this->assertTrue($container->hasDefinition('openapi.route_loader'));
+        self::assertTrue($container->hasDefinition('openapi.route_loader'));
         $routeLoader = $container->getDefinition('openapi.route_loader');
-        $this->assertSame([[]], $routeLoader->getTag('routing.loader'));
+        self::assertSame([[]], $routeLoader->getTag('routing.loader'));
     }
 
-    /**
-     * @test
-     */
-    public function hasAlias()
+    public function testHasAlias()
     {
-        $this->assertSame('api_routing', $this->extension->getAlias());
+        self::assertSame('api_routing', $this->extension->getAlias());
     }
 }

--- a/tests/unit/Routing/OpenApiRouteLoaderTest.php
+++ b/tests/unit/Routing/OpenApiRouteLoaderTest.php
@@ -16,12 +16,13 @@ use KleijnWeb\PhpApi\Descriptions\Description\Repository;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\ScalarSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Schema;
 use KleijnWeb\PhpApi\RoutingBundle\Routing\OpenApiRouteLoader;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Route;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
+class OpenApiRouteLoaderTest extends TestCase
 {
     const DOCUMENT_PATH = '/totally/non-existent/path';
 
@@ -33,7 +34,7 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $decriptionMock;
+    private $descriptionMock;
 
     /**
      * @var OpenApiRouteLoader
@@ -45,7 +46,7 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->decriptionMock = $this
+        $this->descriptionMock = $this
             ->getMockBuilder(Description::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -57,29 +58,23 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->repositoryMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('get')
-            ->willReturn($this->decriptionMock);
+            ->willReturn($this->descriptionMock);
 
         $this->loader = new OpenApiRouteLoader($repository, 'customname');
     }
 
-    /**
-     * @test
-     */
-    public function supportSwaggerAsRouteTypeOnly()
+    public function testSupportSwaggerAsRouteTypeOnly()
     {
-        $this->assertFalse($this->loader->supports('/a/b/c'));
-        $this->assertTrue($this->loader->supports('/a/b/c', 'customname'));
+        self::assertFalse($this->loader->supports('/a/b/c'));
+        self::assertTrue($this->loader->supports('/a/b/c', 'customname'));
     }
 
-    /**
-     * @test
-     */
-    public function canLoadMultipleDocuments()
+    public function testCanLoadMultipleDocuments()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([]);
 
@@ -87,13 +82,10 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $this->loader->load(self::DOCUMENT_PATH.'2');
     }
 
-    /**
-     * @test
-     */
-    public function loadingMultipleDocumentsWillPreventRouteKeyCollisions()
+    public function testLoadingMultipleDocumentsWillPreventRouteKeyCollisions()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn(
                 [
@@ -103,45 +95,37 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routes1 = $this->loader->load(self::DOCUMENT_PATH);
         $routes2 = $this->loader->load(self::DOCUMENT_PATH.'2');
-        $this->assertSame(count($routes1), count(array_diff_key($routes1->all(), $routes2->all())));
+        self::assertSame(count($routes1), count(array_diff_key($routes1->all(), $routes2->all())));
     }
 
-    /**
-     * @test
-     * @expectedException \RuntimeException
-     */
-    public function cannotLoadSameDocumentMoreThanOnce()
+    public function testCannotLoadSameDocumentMoreThanOnce()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([]);
 
+        self::expectException(\RuntimeException::class);
+
         $this->loader->load(self::DOCUMENT_PATH);
         $this->loader->load(self::DOCUMENT_PATH);
     }
 
-    /**
-     * @test
-     */
-    public function willReturnRouteCollection()
+    public function testWillReturnRouteCollection()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([]);
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
-        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $routes);
+        self::assertInstanceOf('Symfony\Component\Routing\RouteCollection', $routes);
     }
 
-    /**
-     * @test
-     */
-    public function routeCollectionWillContainOneRouteForEveryPathAndMethod()
+    public function testRouteCollectionWillContainOneRouteForEveryPathAndMethod()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn(
                 [
@@ -152,16 +136,13 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
-        $this->assertCount(3, $routes);
+        self::assertCount(3, $routes);
     }
 
-    /**
-     * @test
-     */
-    public function shouldCreateRoutesWithTheCorrectHttpSchemes()
+    public function testShouldCreateRoutesWithTheCorrectHttpSchemes()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([
                 new Path('/a', [
@@ -170,27 +151,24 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
                 ]),
             ]);
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getSchemes')
             ->willReturn(['https', 'http']);
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
-        $this->assertCount(2, $routes);
+        self::assertCount(2, $routes);
 
         foreach ($routes as $route) {
-            $this->assertEquals(['https', 'http'], $route->getSchemes());
+            self::assertEquals(['https', 'http'], $route->getSchemes());
         }
     }
 
-    /**
-     * @test
-     */
-    public function routeCollectionWillIncludeSeparateRoutesForSubPaths()
+    public function testRouteCollectionWillIncludeSeparateRoutesForSubPaths()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn(
                 [
@@ -203,18 +181,15 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
-        $this->assertCount(3, $routes);
+        self::assertCount(3, $routes);
     }
 
-    /**
-     * @test
-     */
-    public function canUseOperationIdAsControllerKey()
+    public function testCanUseOperationIdAsControllerKey()
     {
         $expected = 'my.controller.key:methodName';
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([
                 new Path(
@@ -227,19 +202,16 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
         $actual = $routes->get('customname.path.a.methodName');
-        $this->assertNotNull($actual);
-        $this->assertSame($expected, $actual->getDefault('_controller'));
+        self::assertNotNull($actual);
+        self::assertSame($expected, $actual->getDefault('_controller'));
     }
 
-    /**
-     * @test
-     */
-    public function canUseXRouterMethodToOverrideMethod()
+    public function testCanUseXRouterMethodToOverrideMethod()
     {
         $extensions = ['router-controller-method' => 'myMethodName'];
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([
                 new Path(
@@ -255,19 +227,16 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
         $actual = $routes->get('customname.path.a.myMethodName');
-        $this->assertNotNull($actual);
+        self::assertNotNull($actual);
     }
 
-    /**
-     * @test
-     */
-    public function canUseXRouterControllerForDiKeyInOperation()
+    public function testCanUseXRouterControllerForDiKeyInOperation()
     {
         $diKey      = 'my.x_router.controller';
         $expected   = "$diKey:post";
         $extensions = ['router-controller' => $diKey];
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([
                 new Path(
@@ -283,24 +252,21 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
         $actual = $routes->get('customname.path.a.post');
-        $this->assertNotNull($actual);
-        $this->assertSame($expected, $actual->getDefault('_controller'));
+        self::assertNotNull($actual);
+        self::assertSame($expected, $actual->getDefault('_controller'));
     }
 
-    /**
-     * @test
-     */
-    public function canUseXRouterControllerForDiKeyInPath()
+    public function testCanUseXRouterControllerForDiKeyInPath()
     {
         $diKey    = 'my.x_router.controller';
         $expected = "$diKey:post";
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([new Path('/a', [new Operation('/a:post', '/a', 'post')])]);
 
-        $this->decriptionMock
-            ->expects($this->atLeast(1))
+        $this->descriptionMock
+            ->expects(self::atLeast(1))
             ->method('getExtension')
             ->willReturnCallback(
                 function (string $name) use ($diKey) {
@@ -311,24 +277,21 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
         $actual = $routes->get('customname.path.a.post');
-        $this->assertNotNull($actual);
-        $this->assertSame($expected, $actual->getDefault('_controller'));
+        self::assertNotNull($actual);
+        self::assertSame($expected, $actual->getDefault('_controller'));
     }
 
-    /**
-     * @test
-     */
-    public function canUseXRouterForDiKeyInPath()
+    public function testCanUseXRouterForDiKeyInPath()
     {
         $router   = 'my.x_router';
         $expected = "$router.a:post";
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([new Path('/a', [new Operation('/a:post', '/a', 'post')])]);
 
-        $this->decriptionMock
-            ->expects($this->atLeast(1))
+        $this->descriptionMock
+            ->expects(self::atLeast(1))
             ->method('getExtension')
             ->willReturnCallback(
                 function (string $name) use ($router) {
@@ -339,17 +302,14 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
         $actual = $routes->get('customname.path.a.post');
-        $this->assertNotNull($actual);
-        $this->assertSame($expected, $actual->getDefault('_controller'));
+        self::assertNotNull($actual);
+        self::assertSame($expected, $actual->getDefault('_controller'));
     }
 
-    /**
-     * @test
-     */
-    public function routeCollectionWillIncludeSeparateRoutesForSubPathMethodCombinations()
+    public function testRouteCollectionWillIncludeSeparateRoutesForSubPathMethodCombinations()
     {
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([
                 new Path(
@@ -365,13 +325,10 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
-        $this->assertCount(4, $routes);
+        self::assertCount(4, $routes);
     }
 
-    /**
-     * @test
-     */
-    public function routeCollectionWillContainPathFromDescription()
+    public function testRouteCollectionWillContainPathFromDescription()
     {
         $paths = [
             new Path('/a', [new Operation('/a:get', '/a', 'get'),]),
@@ -383,8 +340,8 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
             new Path('/z', [new Operation('/z:get', '/z', 'get'),]),
         ];
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn($paths);
 
@@ -406,13 +363,10 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
         );
 
         sort($routePaths);
-        $this->assertSame($descriptionPaths, $routePaths);
+        self::assertSame($descriptionPaths, $routePaths);
     }
 
-    /**
-     * @test
-     */
-    public function willAddRequirementsForIntegerPathParams()
+    public function testWillAddRequirementsForIntegerPathParams()
     {
         $parameter = new Parameter(
             'foo',
@@ -421,24 +375,21 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
             Parameter::IN_PATH
         );
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([new Path('/a', [new Operation('/a:get', '/a', 'get', [$parameter])])]);
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
         $actual = $routes->get('customname.path.a.get');
-        $this->assertNotNull($actual);
+        self::assertNotNull($actual);
         $requirements = $actual->getRequirements();
-        $this->assertNotNull($requirements);
+        self::assertNotNull($requirements);
 
-        $this->assertSame($requirements['foo'], '\d+');
+        self::assertSame($requirements['foo'], '\d+');
     }
 
-    /**
-     * @test
-     */
-    public function willAddRequirementsForStringPatternParams()
+    public function testWillAddRequirementsForStringPatternParams()
     {
         $expected  = '\d{2}hello';
         $parameter = new Parameter(
@@ -453,24 +404,21 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
             Parameter::IN_PATH
         );
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([new Path('/a', [new Operation('/a:get', '/a', 'get', [$parameter])])]);
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
         $actual = $routes->get('customname.path.a.get');
-        $this->assertNotNull($actual);
+        self::assertNotNull($actual);
         $requirements = $actual->getRequirements();
-        $this->assertNotNull($requirements);
+        self::assertNotNull($requirements);
 
         $this->assertSame($expected, $requirements['aString']);
     }
 
-    /**
-     * @test
-     */
-    public function willAddRequirementsForStringEnumParams()
+    public function testWillAddRequirementsForStringEnumParams()
     {
         $enum      = ['a', 'b', 'c'];
         $expected  = '(a|b|c)';
@@ -486,17 +434,17 @@ class OpenApiRouteLoaderTest extends \PHPUnit_Framework_TestCase
             Parameter::IN_PATH
         );
 
-        $this->decriptionMock
-            ->expects($this->any())
+        $this->descriptionMock
+            ->expects(self::any())
             ->method('getPaths')
             ->willReturn([new Path('/a', [new Operation('/a:get', '/a', 'get', [$parameter])])]);
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
         $actual = $routes->get('customname.path.a.get');
-        $this->assertNotNull($actual);
+        self::assertNotNull($actual);
         $requirements = $actual->getRequirements();
-        $this->assertNotNull($requirements);
+        self::assertNotNull($requirements);
 
-        $this->assertSame($expected, $requirements['aString']);
+        self::assertSame($expected, $requirements['aString']);
     }
 }

--- a/tests/unit/Routing/RequestMetaTest.php
+++ b/tests/unit/Routing/RequestMetaTest.php
@@ -13,56 +13,49 @@ use KleijnWeb\PhpApi\Descriptions\Description\Operation;
 use KleijnWeb\PhpApi\Descriptions\Description\Path;
 use KleijnWeb\PhpApi\Descriptions\Description\Repository;
 use KleijnWeb\PhpApi\RoutingBundle\Routing\RequestMeta;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class RequestMetaTest extends \PHPUnit_Framework_TestCase
+class RequestMetaTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function createFromRequestWillReturnNullWhenUriAttributeNotSet()
+    public function testCreateFromRequestWillReturnNullWhenUriAttributeNotSet()
     {
         $request = new Request();
         $meta    = RequestMeta::fromRequest($request, new Repository());
-        $this->assertNull($meta);
+        self::assertNull($meta);
     }
 
-    /**
-     * @test
-     */
-    public function canCreateFromRequest()
+    public function testCanCreateFromRequest()
     {
         $request = $this->createRequest('/foo.yml', '/foo');
         $meta    = RequestMeta::fromRequest($request, $this->stubRepository());
-        $this->assertInstanceOf(RequestMeta::class, $meta);
+        self::assertInstanceOf(RequestMeta::class, $meta);
 
         return $meta;
     }
 
-    /**
-     * @test
-     */
-    public function willReuseInstance()
+    public function testWillReuseInstance()
     {
         $repository = $this->stubRepository();
 
         $request = $this->createRequest('/foo.yml', '/foo');
         $meta    = RequestMeta::fromRequest($request, $repository);
 
-        $this->assertSame($meta, RequestMeta::fromRequest($request, $repository));
+        self::assertSame($meta, RequestMeta::fromRequest($request, $repository));
     }
 
     /**
-     * @test
+     * @depends testCanCreateFromRequest
+     *
+     * @param RequestMeta $meta
      */
-    public function canUseGetters()
+    public function testCanUseGetters(RequestMeta $meta)
     {
-        $meta = $this->canCreateFromRequest();
-        $this->assertTrue(is_subclass_of($meta->getDescription(), Description::class));
-        $this->assertTrue(is_subclass_of($meta->getOperation(), Operation::class));
+        self::assertTrue(is_subclass_of($meta->getDescription(), Description::class));
+        self::assertTrue(is_subclass_of($meta->getOperation(), Operation::class));
     }
 
     /**
@@ -85,9 +78,9 @@ class RequestMetaTest extends \PHPUnit_Framework_TestCase
         $path        = $this->getMockBuilder(Path::class)->disableOriginalConstructor()->getMock();
         $operation   = $this->getMockBuilder(Operation::class)->disableOriginalConstructor()->getMock();
 
-        $repository->expects($this->once())->method('get')->willReturn($description);
-        $description->expects($this->once())->method('getPath')->willReturn($path);
-        $path->expects($this->once())->method('getOperation')->willReturn($operation);
+        $repository->expects(self::once())->method('get')->willReturn($description);
+        $description->expects(self::once())->method('getPath')->willReturn($path);
+        $path->expects(self::once())->method('getOperation')->willReturn($operation);
 
         return $repository;
     }


### PR DESCRIPTION
> PHPUnit 5.7 is the old stable release series.
> It became stable on December 2, 2016.
> Support for PHPUnit 5 ends on February 2, 2018.
> — https://phpunit.de/