### PR TITLE
Add support for invokable controllers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,12 @@
   "description": "Symfony routing using php-api-descriptions",
   "autoload": {
     "psr-4": {
-      "KleijnWeb\\PhpApi\\RoutingBundle\\Tests\\": "tests",
       "KleijnWeb\\PhpApi\\RoutingBundle\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "KleijnWeb\\PhpApi\\RoutingBundle\\Tests\\": "tests/unit"
     }
   },
   "keywords": [

--- a/src/Routing/OpenApiRouteLoader.php
+++ b/src/Routing/OpenApiRouteLoader.php
@@ -200,7 +200,7 @@ class OpenApiRouteLoader extends Loader
     {
         $controllerSegments = explode(':', $controllerKey);
 
-        $operationName = 'invokable';
+        $operationName = 'action';
         if (count($controllerSegments) === 2) {
             list(, $operationName) = $controllerSegments;
         }

--- a/src/Routing/OpenApiRouteLoader.php
+++ b/src/Routing/OpenApiRouteLoader.php
@@ -169,6 +169,9 @@ class OpenApiRouteLoader extends Loader
             if (false !== strpos($operation->getId(), ':')) {
                 return $operation->getId();
             }
+            if (method_exists($operation->getId(), '__invoke')) {
+                return $operation->getId();
+            }
             $operationName = $operation->getId();
         }
 
@@ -195,7 +198,13 @@ class OpenApiRouteLoader extends Loader
      */
     private function createRouteId(string $resource, string $path, string $controllerKey): string
     {
-        list(, $operationName) = explode(':', $controllerKey);
+        $controllerSegments = explode(':', $controllerKey);
+
+        $operationName = 'invokable';
+        if (count($controllerSegments) === 2) {
+            list(, $operationName) = $controllerSegments;
+        }
+
         $fileName       = pathinfo($resource, PATHINFO_FILENAME);
         $normalizedPath = strtolower(trim(preg_replace('/\W+/', '.', $path), '.'));
         $routeName      = "$this->typeName.{$fileName}.$normalizedPath.$operationName";

--- a/tests/unit/Routing/OpenApiRouteLoaderTest.php
+++ b/tests/unit/Routing/OpenApiRouteLoaderTest.php
@@ -239,7 +239,7 @@ class OpenApiRouteLoaderTest extends TestCase
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
-        $actual = $routes->get('customname.path.a.invokable');
+        $actual = $routes->get('customname.path.a.action');
         $this->assertNotNull($actual);
         $this->assertSame($expected, $actual->getDefault('_controller'));
     }

--- a/tests/unit/Routing/OpenApiRouteLoaderTest.php
+++ b/tests/unit/Routing/OpenApiRouteLoaderTest.php
@@ -518,7 +518,8 @@ namespace An\Inokable;
 
 use Symfony\Component\HttpFoundation\Response;
 
-class Controller {
+class Controller
+{
     public function __invoke(): Response
     {
         return new Response();


### PR DESCRIPTION
This adds support for invokable controllers.

I'm not happy with the `invokable` name being part of the route name though. I wanted to open this up so it could be discussed. Maybe `action` would be better as this pattern is known as ADR (Action/Domain/Responder)?

Closes #2.