### PR TITLE
Fixed duplicate route names with multiple http methods when using invokable controllers.

### DIFF
--- a/src/Routing/OpenApiRouteLoader.php
+++ b/src/Routing/OpenApiRouteLoader.php
@@ -199,9 +199,12 @@ class OpenApiRouteLoader extends Loader
     {
         $controllerSegments = explode(':', $controllerKey);
 
-        $operationName = 'action';
         if (count($controllerSegments) === 2) {
             list(, $operationName) = $controllerSegments;
+        } else {
+            $className = basename(str_replace('\\', '/', $controllerKey));
+            // Convert class name to snake_case
+            $operationName = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $className));
         }
 
         $fileName       = pathinfo($resource, PATHINFO_FILENAME);

--- a/tests/unit/Routing/OpenApiRouteLoaderTest.php
+++ b/tests/unit/Routing/OpenApiRouteLoaderTest.php
@@ -239,7 +239,7 @@ class OpenApiRouteLoaderTest extends TestCase
 
         $routes = $this->loader->load(self::DOCUMENT_PATH);
 
-        $actual = $routes->get('customname.path.a.action');
+        $actual = $routes->get('customname.path.a.invokable_controller');
         $this->assertNotNull($actual);
         $this->assertSame($expected, $actual->getDefault('_controller'));
     }


### PR DESCRIPTION
This fixes the duplicate names that would occur when using multiple http
methods for a single endpoint when using invokable controllers.

For example:

GET /example would return swagger.api.example.action
POST /example would return swagger.api.example.action